### PR TITLE
this patch fixes the location of the configure cmake scripts.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,7 @@ write_basic_package_version_file(
 configure_package_config_file(
     cmake/cpppropertiesConfig.cmake.in
     cmake/cpppropertiesConfig.cmake
-    INSTALL_DESTINATION lib/cmake/)
+    INSTALL_DESTINATION lib/cmake/cppproperties/)
 
 include(GenerateExportHeader)
 generate_export_header(cppproperties)
@@ -73,10 +73,10 @@ install(FILES
 install(FILES
     ${CMAKE_CURRENT_BINARY_DIR}/cmake/cpppropertiesConfig.cmake
     ${CMAKE_CURRENT_BINARY_DIR}/cmake/cpppropertiesConfigVersion.cmake
-    DESTINATION lib/cmake/)
+    DESTINATION lib/cmake/cppproperties/)
 
 install(EXPORT cpppropertiesTargets
-    DESTINATION lib/cmake/)
+    DESTINATION lib/cmake/cppproperties/)
 
 if(ENABLE_TEST)
     enable_testing()


### PR DESCRIPTION
cpp-properties installs config files (on unix / linux) in <prefix>/lib/cmake, while it should be <prefix>/lib/cmake/<name>/